### PR TITLE
src: Add functions for EC2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-sdk = ses,s3,lambda
+sdk = ses,s3,lambda,ec2

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Native support for the entire AWS SDK for JavaScript in Google Apps Script.
 
-Working examples for Simple Email Service (SES), S3, and Lambda. This project can easily accommodate _all_ other AWS services, e.g.,
+Working examples for Simple Email Service (SES), S3, Lambda, and EC2. This project can easily accommodate _all_ other AWS services, e.g.,
 
 ```
 npm run sdk --sdk=ses,s3,ec2,lambda,dynamodb && npm run build
@@ -19,7 +19,7 @@ npm run sdk --sdk=ses,s3,ec2,lambda,dynamodb && npm run build
 - Choose an identifier, e.g., `AWSLIB`
 - Versions of the Google Apps Script project map to tags on this Git repository
 
-2. Initialize your AWS config settings and implement one of this library's [S3](dist/S3.js), [Lambda](dist/Lambda.js), or [SES](dist/Ses.js) functions. [Examples.js](dist/Examples.js) shows some working examples.
+2. Initialize your AWS config settings and implement one of this library's [S3](dist/S3.js), [Lambda](dist/Lambda.js), [SES](dist/Ses.js), or [EC2](dist/EC2.js) functions. [Examples.js](dist/Examples.js) shows some working examples.
 
 ```js
 const AWS_CONFIG = {
@@ -42,7 +42,7 @@ async function getS3ObjectTest() {
 }
 ```
 
-3. Methods for common S3, Lambda, and SES services have been implemented. However, direct access to library AWS SDK methods is also available via the `AWS` property on your chosen library identifier, e.g.:
+3. Methods for common S3, Lambda, SES, and EC2 services have been implemented. However, direct access to library AWS SDK methods is also available via the `AWS` property on your chosen library identifier, e.g.:
 
 ```js
 // Create a new service object
@@ -64,7 +64,7 @@ var s3 = new AWSLIB.AWS.S3({
 
 The AWS SDK can be customized for specific API versions and/or services.
 
-This project defaults to the following services: `ses,s3,lambda`.
+This project defaults to the following services: `ses,s3,lambda,ec2`.
 
 To customize the codebase for your project:
 

--- a/src/EC2.js
+++ b/src/EC2.js
@@ -1,0 +1,35 @@
+function listEC2Instances(region = null) {
+  var ec2Promise = new AWS.EC2({
+    apiVersion: '2016-11-15',
+    region: region || AWS.config.region,
+  })
+    .describeInstances()
+    .promise();
+
+  return ec2Promise
+    .then((data) => {
+      return data;
+    })
+    .catch((err) => {
+      Logger.log(err, err.stack);
+      return false;
+    });
+}
+
+function listSecurityGroups(region = null) {
+  var ec2Promise = new AWS.EC2({
+    apiVersion: '2016-11-15',
+    region: region || AWS.config.region,
+  })
+    .describeSecurityGroups()
+    .promise();
+
+  return ec2Promise
+    .then((data) => {
+      return data;
+    })
+    .catch((err) => {
+      Logger.log(err, err.stack);
+      return false;
+    });
+}

--- a/src/Examples.js
+++ b/src/Examples.js
@@ -64,3 +64,33 @@ async function invokeLambdaTest() {
   Logger.log(result);
   return result;
 }
+
+async function listEC2InstancesTest() {
+  initConfig(AWS_CONFIG_TEST);
+  var result = await listEC2Instances('us-west-2');
+  var instances = [];
+
+  if (result !== false) {
+    if (result.hasOwnProperty('reservationSet') && result.reservationSet.hasOwnProperty('instancesSet')) {
+      instances = result.reservationSet.instancesSet;
+    }
+  }
+
+  Logger.log(`${instances.length} instance${instances.length === 1 ? '' : 's'}`);
+  return instances;
+}
+
+async function listSecurityGroupsTest() {
+  initConfig(AWS_CONFIG_TEST);
+  var result = await listSecurityGroups('us-west-2');
+  var groups = [];
+
+  if (result !== false) {
+    if (result.hasOwnProperty('securityGroupInfo')) {
+      groups = result.securityGroupInfo;
+    }
+  }
+
+  Logger.log(`${groups.length} security group${groups.length === 1 ? '' : 's'}`);
+  return groups;
+}


### PR DESCRIPTION
Add some functinos to interface with AWS EC2 apis (EC2 instances and security groups)
Also add it in Examples.js with some tests

Finally update the documentation to mention that EC2 will be included by default

Fixes https://github.com/dxdc/aws-sdk-google-apps/issues/9